### PR TITLE
Add directions about disableDependencyReinclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,15 @@ echo '# Hello' > src/hello.md
 echo '<h1>Hi!</h1>' > src/Hi.svench
 yarn svench
 ```
+
+If you are using SvelteKit, add `disableDependencyReinclusion` into your `svelte.config.js` file to prevent `vite-plugin-svelte` from including
+Node-only packages in Vite's prebundling step.
+
+```diff
+const config = {
++  disableDependencyReinclusion: ['svench'],
+   kit: {
+      ...
+   }
+}
+```


### PR DESCRIPTION
When running svench with SvelteKit, vite-plugin-svelte tries to include svench's transitive dependencies in its prebundling step, which fails because this ends up including Node-only packages like `cheap-watch`.

Adding `disableDependencyReinclusion: ['svench']` to `svelte.config.js` fixes this, so I'm submitting a PT to document this. What do you think?